### PR TITLE
Exclude event parameters from particular event

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ This is optional, default value is `allow: [ '*' ]`. If no value is specified, e
 
 This is optional, default value is `deny: []`. If no value is specified, this doesn't affect anything but the decision to send the events will be based on the evaluation of other options provided. If both allow and deny options exist, evaluation of the deny options will determine if the events will be sent to the consumer of not.
 
+* denyParameters
+This is an optional parameter. You can use denyParameters to exclude sending particular event parameter for an event. Specify an array of objects. Each object should have eventId and parameters as an array.
+
 ```
 { name: 'consumer' } // Send all events to the consumer
 { name: 'consumer', allow: [] } // No events will be sent to the consumer
@@ -49,6 +52,7 @@ This is optional, default value is `deny: []`. If no value is specified, this do
 { name: 'consumer', allow: [ 'user.login.' ]  } // All events matching user.login.* will be sent to the consumer
 { name: 'consumer', deny: [ '*' ] } // No events will be sent to the consumer
 { name: 'consumer', allow: [ 'user.login.' ], deny: [ 'user.login.failed' ] } // Send all events which matches the namespace user.login.* but don't send user.login.failed event.
+{ name: 'consumer', allow: [ '*' ], denyParameters: [ { eventId: 'user.login.failed', parameters: [ 'location' ] } ] } // Exclude sending location parameter with user.login.failed event to the consumer.
 ```
 
 Configuration allows us to configure the consumers whatever the way we want, it up to you to decide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/siddi",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/siddi",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A convenient event tracker API which sends events to multiple consumers",
   "main": "dist/siddi.js",
   "scripts": {

--- a/src/__tests__/siddi.spec.ts
+++ b/src/__tests__/siddi.spec.ts
@@ -136,5 +136,21 @@ describe('Siddi', () => {
       siddi.track('unitTest.track', { run: 'last' });
       expect(mixpanelTrackSpy).toBeCalledWith('unitTest.track', { run: 'last' });
     });
+    it('should not send event parameters with tracking data when that event parameters defined in denyParameters', () => {
+      mixpanelTestSpy.mockReturnValue(true);
+      siddi = new Siddi([{ name: 'mixpanel', allow: ['*'], denyParameters: [{eventId:'unitTest.track', parameters:['where', 'why']}] }]);
+      siddi.track('unitTest.track', { run: 'last', where: 'mac', why: 'denny' });
+      expect(mixpanelTestSpy).toBeCalled();
+      expect(mixpanelIdentifySpy).not.toBeCalled();
+      expect(mixpanelTrackSpy).toBeCalledWith('unitTest.track', { run: 'last' });
+    });
+    it('should only exclude event parameters which are defined in denyParameters', () => {
+      mixpanelTestSpy.mockReturnValue(true);
+      siddi = new Siddi([{ name: 'mixpanel', allow: ['*'], denyParameters: [{eventId:'unitTest.track', parameters:['param']}] }]);
+      siddi.track('unitTest.run', { run: 'last', param: 'value' });
+      expect(mixpanelTestSpy).toBeCalled();
+      expect(mixpanelIdentifySpy).not.toBeCalled();
+      expect(mixpanelTrackSpy).toBeCalledWith('unitTest.run', { run: 'last', param: 'value' });
+    });
   });
 });

--- a/src/siddi.ts
+++ b/src/siddi.ts
@@ -70,7 +70,7 @@ export class Siddi {
   public track(eventName: string, eventProperties: any): void {
     this.consumerConfig.forEach(config => {
       // Assign event properties to a new obeject
-      var filteredEventProperties = Object.assign({}, eventProperties);
+      let filteredEventProperties = Object.assign({}, eventProperties);
       // consumer name must exist, else ignore it
       if (config.name && Consumers[config.name] && this.shouldTrack(config, eventName)) {
         // If no consumer status tracking exist, check it first

--- a/src/siddi.ts
+++ b/src/siddi.ts
@@ -19,7 +19,7 @@ import { Consumers } from './consumers';
  * 5. { name: 'mixpanel', allow: [ '*' ], deny: [ 'site.login.', 'app.user.' ] } --> Do not send site.login.* and app.user.* events
  * 6. { name: 'mixpanel', deny: [ 'user.collab.' ] } --> Do not send user.collab.* events
  */
-export type EventConfiguration = { name: string; allow?: string[]; deny?: string[] };
+export type EventConfiguration = { name: string; allow?: string[]; deny?: string[]; denyParameters?: any };
 
 /**
  * Siddi - An abstract event consumer
@@ -68,6 +68,8 @@ export class Siddi {
    */
   public track(eventName: string, eventProperties: any): void {
     this.consumerConfig.forEach(config => {
+      // Assign event properties to a new obeject
+      var filteredEventProperties = Object.assign({}, eventProperties);
       // consumer name must exist, else ignore it
       if (config.name && Consumers[config.name] && this.shouldTrack(config, eventName)) {
         // If no consumer status tracking exist, check it first
@@ -85,6 +87,18 @@ export class Siddi {
           }
         }
 
+        // Exclude sending event parameters for particular event
+        // when those defined in denyParameters config
+        if(eventProperties && config.denyParameters) {
+          config.denyParameters.some(function(element: any, index: number) {
+              if(element.eventId === eventName) {
+                config.denyParameters[index].parameters.forEach(function(property: string) {
+                  delete filteredEventProperties[property];
+                });
+              }
+          });
+        }
+
         // Track the event only if consumer is in enabled status
         // We do not send tracking data to consumers knowingly that they would fail
         if (this.consumerStatus[config.name].enabled) {
@@ -94,7 +108,7 @@ export class Siddi {
             this.consumerStatus[config.name].identified = true;
           }
           new Promise(resolve => {
-            Consumers[config.name].track(eventName, eventProperties);
+            Consumers[config.name].track(eventName, filteredEventProperties);
             resolve();
           });
         }

--- a/src/siddi.ts
+++ b/src/siddi.ts
@@ -18,6 +18,7 @@ import { Consumers } from './consumers';
  * 4. { name: 'mixpanel', allow: [ 'site.' ] } --> All site events will be sent
  * 5. { name: 'mixpanel', allow: [ '*' ], deny: [ 'site.login.', 'app.user.' ] } --> Do not send site.login.* and app.user.* events
  * 6. { name: 'mixpanel', deny: [ 'user.collab.' ] } --> Do not send user.collab.* events
+ * 7. { name: 'mixpanel', denyParameters: [ {eventId: 'user.login.failed', parameters: ['location'] } ] } --> Do not send location parameter with user.login.failed event
  */
 export type EventConfiguration = { name: string; allow?: string[]; deny?: string[]; denyParameters?: any };
 


### PR DESCRIPTION
[Issue ](https://github.com/creately/siddi/issues/33)

[Favro](https://favro.com/organization/c9668dc39f1bd49fed254201/97724606ed6f82a511f41603?card=Cre-19611)

Adding a new feature to exclude sending event parameters for a particular event.

Sample tracker config
```
{
    name: 'snowplow',
    allow: [
        'phoenix.common.load',
        ...
    ],
    denyParameters: [
        {
            eventId: 'phoenix.common.load',
            parameters: [
                'nonInteraction',
                ...
            ]
        }
    ]
}
```