### PR TITLE
Add indicative support to Siddi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/siddi",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/siddi",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A convenient event tracker API which sends events to multiple consumers",
   "main": "dist/siddi.js",
   "scripts": {

--- a/src/__tests__/consumers.spec.ts
+++ b/src/__tests__/consumers.spec.ts
@@ -48,6 +48,14 @@ describe('Consumers', () => {
     identify: () => {},
   };
 
+  const indicative = {
+    test: () => {},
+    track: () => {},
+    identify: () => {},
+    setUniqueID: () => {},
+    buildEvent: () => {},
+  };
+
   describe('mixpanel', () => {
     beforeEach(() => {
       window.mixpanel = mixpanel;
@@ -379,6 +387,41 @@ describe('Consumers', () => {
         it('should send given tracking data', () => {
           Consumers.ga4.track('event.name', { prop: 'a prop' });
           expect(window.gtag).toHaveBeenCalledWith('event', 'event.name', { prop: 'a prop' });
+        });
+      });
+    });
+    describe('indicative', () => {
+      describe('test', () => {
+        it('should return false if indicative is not loaded', () => {
+          expect(Consumers.indicative.test()).toBeFalsy();
+        });
+        it('should true if indicative is loaded', () => {
+          window.Indicative = indicative;
+          expect(Consumers.indicative.test()).toBeTruthy();
+        });
+      });
+      describe('identify', () => {
+        beforeEach(() => {
+          window.Indicative = indicative;
+          jest.spyOn(indicative, 'setUniqueID');
+        });
+        it('should register given user', () => {
+          Consumers.indicative.identify('user-id');
+          expect(indicative.setUniqueID).toHaveBeenCalledWith('user-id', true);
+        });
+        it('should not modify any user properties', () => {
+          Consumers.indicative.identify('user-id', { plan: 'trial' });
+          expect(window.Indicative.setUniqueID).toHaveBeenCalledWith('user-id', true);
+        });
+      });
+      describe('track', () => {
+        beforeEach(() => {
+          window.Indicative = indicative;
+          jest.spyOn(indicative, 'buildEvent');
+        });
+        it('should send given tracking data', () => {
+          Consumers.indicative.track('event.name', { prop: 'a prop' });
+          expect(window.Indicative.buildEvent).toHaveBeenCalledWith('event.name', { prop: 'a prop' });
         });
       });
     });

--- a/src/__tests__/consumers.spec.ts
+++ b/src/__tests__/consumers.spec.ts
@@ -49,9 +49,6 @@ describe('Consumers', () => {
   };
 
   const indicative = {
-    test: () => {},
-    track: () => {},
-    identify: () => {},
     setUniqueID: () => {},
     buildEvent: () => {},
   };

--- a/src/consumers.ts
+++ b/src/consumers.ts
@@ -27,6 +27,7 @@ declare global {
     snowplowschema: string; //Variable which holds the schema path
     sendinblue: any;
     gtag: any;
+    Indicative: any;
   }
 }
 
@@ -125,6 +126,15 @@ export const Consumers: ConsumerConfiguration = {
     },
     track: (eventName: string, eventProperties: any) => {
       window.gtag('event', eventName, eventProperties);
+    },
+  },
+  indicative: {
+    test: () => window.Indicative,
+    identify: (userId: string, _: any = {}) => {
+      window.Indicative.setUniqueID(userId, true);
+    },
+    track: (eventName: string, eventProperties: any) => {
+      window.Indicative.buildEvent(eventName, eventProperties);
     },
   },
 };


### PR DESCRIPTION
https://favro.com/organization/c9668dc39f1bd49fed254201/f1af54eb33aa9692bc7a6a2d?card=Cre-20900

Sample configuration
```
{
    name: 'indicative', 
    allow: [
        'phoenix.signin.',
        'phoenix.signup.',
        'phoenix.sociallogin.'
    ]
}
```
